### PR TITLE
adding parts of aggregated elements in output json

### DIFF
--- a/Xbim.Exchanger/IfcToCOBieLiteUK/COBieLiteUKHelper.cs
+++ b/Xbim.Exchanger/IfcToCOBieLiteUK/COBieLiteUKHelper.cs
@@ -602,7 +602,7 @@ namespace XbimExchanger.IfcToCOBieLiteUK
 
             //retrieve all the IfcElements from the model and exclude them if they are a member of an IIfcType, 
             var unCategorizedAssets = _model.Instances.OfType<IIfcElement>()
-                .Where(t => !(t is IIfcFeatureElement) && !assemblyParts.Contains(t) && !Filter.ObjFilter(t)) //filter IIfcElement it IIfcTypeObject it is defined by is in excluded list of IIfcTypeobjects
+                .Where(t => !(t is IIfcFeatureElement) && !Filter.ObjFilter(t)) 
                 .Except(existingAssets);
             //convert to a Lookup with the key the type of the IIfcElement and the value a list of IIfcElements
             //if the object has a classification we use this to distinguish types

--- a/Xbim.Exchanger/IfcToCOBieLiteUK/MappingIfcBuildingToFacility.cs
+++ b/Xbim.Exchanger/IfcToCOBieLiteUK/MappingIfcBuildingToFacility.cs
@@ -40,7 +40,7 @@ namespace XbimExchanger.IfcToCOBieLiteUK
                 //Facility Attributes
                 facility.Attributes = helper.GetAttributes(ifcBuilding);
                 
-                if (ifcSite != null)
+                if (ifcSite != null && facility.Attributes != null)
                 {
                     facility.Site = new Site();
                     siteMapping.AddMapping(ifcSite, facility.Site);

--- a/Xbim.Exchanger/IfcToCOBieLiteUK/MappingIfcElementToComponent.cs
+++ b/Xbim.Exchanger/IfcToCOBieLiteUK/MappingIfcElementToComponent.cs
@@ -65,11 +65,29 @@ namespace XbimExchanger.IfcToCOBieLiteUK
             //    space.KeyType = EntityType.Space;
             //    target.Spaces.Add(space);
             //}
+            else // if it is part of an aggregated element, add spaces of the aggregated element
+            {
+                var assemblyParts = ifcElement.Model.Instances.OfType<IIfcRelAggregates>().Where(b => b.RelatedObjects.Contains(ifcElement)).FirstOrDefault();
+                if (assemblyParts != null)
+                {
+                    ifcSpatialStructureElements = helper.GetSpaces((IIfcElement)assemblyParts.RelatingObject).ToList();
+                    target.Spaces = new List<SpaceKey>();
+                    if (ifcSpatialStructureElements.Any())
+                    {
+
+                        foreach (var spatialElement in ifcSpatialStructureElements)
+                        {
+                            var Fspace = new SpaceKey { Name = spatialElement.Name };
+                            target.Spaces.Add(Fspace);
+                        }
+                    }
+                }
+            }
 
 
             //Issues
 
-            
+
             return target;
         }
 


### PR DESCRIPTION
in order to have coherent .jon and .wexbim files, added parts of aggregated elements (like roofs, stairs, curtainwalls,..) and corresponding spaces  in json output
tested with XbimWebUI on different models, all elements of models are now displayed by browser